### PR TITLE
Improve network client usage and timeouts

### DIFF
--- a/app/src/main/java/io/github/adam_lally/bookscope/BookDetectorUsingFunctionCalling.kt
+++ b/app/src/main/java/io/github/adam_lally/bookscope/BookDetectorUsingFunctionCalling.kt
@@ -10,8 +10,9 @@ import com.aallam.openai.api.chat.ToolCall
 import com.aallam.openai.api.chat.ToolChoice
 import com.aallam.openai.api.chat.chatCompletionRequest
 import com.aallam.openai.api.model.ModelId
-import com.aallam.openai.client.OpenAI
-import com.example.bookscope.BuildConfig
+import io.github.adam_lally.bookscope.NetworkClients
+import io.github.adam_lally.bookscope.retryWithBackoff
+import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -38,14 +39,14 @@ class BookDetectorUsingFunctionCalling: BookDetector {
     override suspend fun detectBooksInImage(imageUrl: String): BookDetectorResult = coroutineScope {
         try {
             //Call the LLM to get its tool calls
-            val openAi = OpenAI(BuildConfig.OPENAI_API_KEY)
-            val modelId = ModelId("gpt-4o-mini")
+            val openAi = NetworkClients.openAI
+            val modelId = ModelId("gpt-4o")
             val chatMessages =  mutableListOf(
                 ChatMessage(
                     role = ChatRole.System,
-                    content = "You are a helpful assistant who identifies all of the books in an image. " +
+                    content = "You are a helpful assistant who identifies all of the books clearly visible in an image. " +
                             "Use the provided tool to get information about a book given the title and author. " +
-                            "Only return results where there is a good match between the book in the image and the book info from the tool."
+                            "Only return results when you are confident the book is present and matches the tool information."
                 ),
                 ChatMessage(
                     role = ChatRole.User,
@@ -63,7 +64,9 @@ class BookDetectorUsingFunctionCalling: BookDetector {
                 messages = chatMessages
                 tools(getBookInfoToolBuilder())
             }
-            val completion: ChatCompletion = openAi.chatCompletion(chatCompletionRequest)
+            val completion: ChatCompletion = withTimeout(60_000) {
+                retryWithBackoff { openAi.chatCompletion(chatCompletionRequest) }
+            }
             val message =  completion.choices.first().message
             if (message.toolCalls.isNullOrEmpty()) {
                 BookDetectorResult(message = message.content ?: "No books detected")
@@ -105,7 +108,9 @@ class BookDetectorUsingFunctionCalling: BookDetector {
                     tools(foundBooksToolBuilder())
                     toolChoice = ToolChoice.function("foundBooks")
                 }
-                val secondResponse = openAi.chatCompletion(secondChatCompletionRequest)
+                val secondResponse = withTimeout(60_000) {
+                retryWithBackoff { openAi.chatCompletion(secondChatCompletionRequest) }
+            }
                 val toolCall = secondResponse.choices.first().message.toolCalls?.firstOrNull()
                 require(toolCall is ToolCall.Function)
                 val bookInfos = Json.decodeFromString<BookInfos>(toolCall.function.arguments)

--- a/app/src/main/java/io/github/adam_lally/bookscope/NetworkClients.kt
+++ b/app/src/main/java/io/github/adam_lally/bookscope/NetworkClients.kt
@@ -1,0 +1,33 @@
+package io.github.adam_lally.bookscope
+
+import com.aallam.openai.client.OpenAI
+import com.example.bookscope.BuildConfig
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.json.Json
+
+/**
+ * Lazily instantiated network clients reused across the app to
+ * reduce overhead and enable centralized configuration.
+ */
+object NetworkClients {
+    /** OpenAI client shared by all calls. */
+    val openAI: OpenAI by lazy {
+        OpenAI(BuildConfig.OPENAI_API_KEY)
+    }
+
+    /** HttpClient for all OpenLibrary requests. */
+    val openLibraryHttpClient: HttpClient by lazy {
+        HttpClient(CIO) {
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true })
+            }
+            install(HttpTimeout) {
+                requestTimeoutMillis = 15_000
+            }
+        }
+    }
+}

--- a/app/src/main/java/io/github/adam_lally/bookscope/OpenLibrary.kt
+++ b/app/src/main/java/io/github/adam_lally/bookscope/OpenLibrary.kt
@@ -1,14 +1,15 @@
 package io.github.adam_lally.bookscope
 
-import io.ktor.client.HttpClient
 import io.ktor.client.call.body
-import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.coroutines.withTimeout
+import io.github.adam_lally.bookscope.NetworkClients
+import io.github.adam_lally.bookscope.retryWithBackoff
 
 @Serializable
 data class OpenLibrarySearchResult(
@@ -20,24 +21,22 @@ data class OpenLibrarySearchResult(
  * Call the openlibrary API to search for books with the given title and author.
  */
 suspend fun searchBooks(title: String, author: String?): OpenLibrarySearchResult {
-    val client = HttpClient(CIO) {
-        install(ContentNegotiation) {
-            json(Json { ignoreUnknownKeys = true })
+    val client = NetworkClients.openLibraryHttpClient
+
+    val response: OpenLibrarySearchResult = withTimeout(15_000) {
+        retryWithBackoff {
+            client.get("https://openlibrary.org/search.json") {
+                parameter("limit", 3)
+                parameter("title", title)
+                if (author != "Unknown") parameter("author", author)
+            }.body()
         }
     }
 
-    val response: OpenLibrarySearchResult = client.get("https://openlibrary.org/search.json") {
-        parameter("limit", 3)
-        parameter("title", title)
-        if (author != "Unknown") parameter("author", author)
-    }.body()
-
-    client.close()
     return response
 }
 
 /**
- * Get [BookInfo] for the first book found with the given title and author.
  */
 suspend fun getBookInfo(title: String, author: String): BookInfo? {
     val searchResult = searchBooks(title, author)

--- a/app/src/main/java/io/github/adam_lally/bookscope/RetryUtils.kt
+++ b/app/src/main/java/io/github/adam_lally/bookscope/RetryUtils.kt
@@ -1,0 +1,25 @@
+package io.github.adam_lally.bookscope
+
+import kotlinx.coroutines.delay
+
+/**
+ * Retry [block] up to [attempts] using an exponential backoff strategy.
+ */
+suspend fun <T> retryWithBackoff(
+    attempts: Int = 3,
+    initialDelayMillis: Long = 1000,
+    factor: Double = 2.0,
+    block: suspend () -> T
+): T {
+    var currentDelay = initialDelayMillis
+    repeat(attempts - 1) { attempt ->
+        try {
+            return block()
+        } catch (e: Exception) {
+            if (attempt == attempts - 1) throw e
+            delay(currentDelay)
+            currentDelay = (currentDelay * factor).toLong()
+        }
+    }
+    return block()
+}


### PR DESCRIPTION
## Summary
- create `NetworkClients` for shared OpenAI and OpenLibrary clients
- add `retryWithBackoff` helper
- reuse the shared clients inside `BookDetectorUsingFunctionCalling`
- tighten the system prompt and switch to `gpt-4o`
- add request timeouts and retries for OpenAI and OpenLibrary calls

## Testing
- `./gradlew test` *(fails: No route to host)*